### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "jsonwebtoken": "^8.5.1",
     "mysql": "^2.17.1",
     "node-sass": "^4.12.0",
-    "npm": "^6.9.0",
     "passport": "^0.4.0",
     "passport-http-bearer": "^1.0.1",
     "passport-local": "^1.0.0",


### PR DESCRIPTION

Hello ParkingWizard!

It seems like you have npm as one of your (dev-) dependency in final-exam-attempt-1.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
